### PR TITLE
Writing to control input ports w/o UI (DSP -> host; via atom output port) - RFC

### DIFF
--- a/lv2/atom/atom.h
+++ b/lv2/atom/atom.h
@@ -64,6 +64,8 @@
 #define LV2_ATOM__frameTime     LV2_ATOM_PREFIX "frameTime"      ///< http://lv2plug.in/ns/ext/atom#frameTime
 #define LV2_ATOM__supports      LV2_ATOM_PREFIX "supports"       ///< http://lv2plug.in/ns/ext/atom#supports
 #define LV2_ATOM__timeUnit      LV2_ATOM_PREFIX "timeUnit"       ///< http://lv2plug.in/ns/ext/atom#timeUnit
+#define LV2_ATOM__PortEvent     LV2_ATOM_PREFIX "PortEvent"      ///< http://lv2plug.in/ns/ext/atom#PortEvent
+#define LV2_ATOM__portTuple     LV2_ATOM_PREFIX "portTuple"      ///< http://lv2plug.in/ns/ext/atom#portTuple
 
 #define LV2_ATOM_REFERENCE_TYPE 0  ///< The special type for a reference atom
 

--- a/lv2/atom/atom.meta.ttl
+++ b/lv2/atom/atom.meta.ttl
@@ -540,3 +540,25 @@ contained in the port, including header.
 
 """^^lv2:Markdown .
 
+atom:PortEvent
+	lv2:documentation """
+
+Write to control input port event message, typically an element of an atom:Sequence.
+
+Provides an atom:portTuple property, consisting of one or more paired tuples.
+Each tuple pair consists of an atom:Int for `port_index`, followed by an
+atom:Float as the respective `port_value`.
+
+"""^^lv2:Markdown .
+
+atom:portTuple
+	lv2:documentation """
+
+The property body of an atom:PortEvent message.
+
+It consists of an array of paired tuples: a `port_index` (atom:Int) and
+a `port_value` (atom:Float). Typically, each pair of `port_index` and
+`port_value` tuples, correspond to an existing port, of lv2:ControlPort
+and lv2:InputPort types.
+
+"""^^lv2:Markdown .

--- a/lv2/atom/atom.ttl
+++ b/lv2/atom/atom.ttl
@@ -245,3 +245,14 @@ atom:atomTransfer
 	rdfs:label "atom transfer" ;
 	rdfs:comment "A port protocol for transferring atoms." .
 
+atom:PortEvent
+	a rdfs:Class ;
+	rdfs:subClassOf atom:Object ;
+	rdfs:label "port event" ;
+	rdfs:comment "Write to control input port event message." .
+
+atom:portTuple
+	a rdf:Property ,
+		owl:ObjectProperty ;
+	rdfs:label "port tuple" ;
+	rdfs:comment "The body property of an atom:PortEvent message." .


### PR DESCRIPTION
As briefly discussed on #lv2 irc and devel@lists.lv2plug.in ...

This is all about tackling an ages old long and overdue problem, eg. one of LV2 instrument plugins that wish to support some kind of not-initiated-by-the-GUI-ever preset/state change: standard MIDI bank+program_change channel messages comes to mind...

Hopefully, this proposal tries to solve one controllers connundrum: plugins are not allowed to override their own input control port values--formerly regarded as parameters on LADSPA and now *legacy* for LV2--which are, as ever were *read-only*, of course: ownership and value is host's prerogative and sole responsability...

So, how do we make a host to update on over a plugin's control input ports you ask? 

Until now that was not possible at all; of course, control input ports are read-only from the plugin's POV; only the host may write to it on its own premises.

This rather simple protocol being here proposed should help on letting the plugin tell the host that it wishes to update or write to one or more input control ports--the host may or may not concur on its own.

And how does the plugin tells so? It does it through one of its atom output ports(*), in the very same and similar fashion like it used to do with patch properties/parameters all the way down: via an LV2 Atom object that is.


TL;DR: This proposal boils down to add just a couple of new URIs to the LV2 reportoire (possibly to `lv2/lv2plug.in/ns/ext/atom/atom.h`):
```C
#define LV2_ATOM__PortEvent LV2_ATOM_PREFIX "PortEvent"
#define LV2_ATOM__portTuple LV2_ATOM_PREFIX "portTuple"
```
Just not sure about namenclature: should it be under the `LV2:Atom` class, like `LV2_ATOM__PortEvent` suggested above? or `LV2_ATOM__PortWrite`? Or should it belong to `LV2:Patch` realm (in `lv2/lv2plug.in/ns/ext/patch/patch.h`) as `LV2_PATCH__PortEvent`, considering that it's similar in semantics to `LV2_PATCH__Put` for LV2:Patch properties/parameters but applying to control input ports instead?

Ontology and design specification looks fine to me as is and the good news are that it's implemented already on yours truly **qtractor** (as host) and the *Vee-One-Suite*, **synthv1**, **samplv1**, **drumkv1** and **padthv1** (as plugins).

---
(*) plural, although having more than one atom output port is quite unusual.

Below you may find some code snippets, as example implementations to either side, host and plugin.

---
Host: ** read_port_event **
```C
#include "lv2/lv2plug.in/ns/ext/atom/util.h"

//  LV2_Atom *atom;
//
//  `atom` is a `LV2_ATOM__Object`, read from the plugin's atom output
//  port buffer, while on the real-time processing thread and then
//  transferred to the main host (non-DSP) thread, possibly via a
//  ring-buffer, wrapped in a `LV2_ATOM__eventTransfer` container.
//
    const LV2_Atom_Object *obj = (const LV2_Atom_Object *) atom;
    // ...
    if (obj->body.otype == _urid_map(LV2_ATOM__PortEvent)) {
        const LV2_Atom_Tuple *tup = nullptr;
        lv2_atom_object_get(obj,
            _urid_map(LV2_ATOM__portTuple), (const LV2_Atom *) &tup, 0);
        uint32_t port_index = 0;
        if (tup) {
            uint32_t port_index = 0;
            LV2_ATOM_TUPLE_FOREACH(tup, iter) {
                if (iter->type == _urid_map(LV2_ATOM__Int))
                    port_index = *(uint32_t *) (iter + 1);
                else
                if (iter->type == _urid_map(LV2_ATOM__Float)) {
                    const uint32_t buffer_size = iter->size;
                    const void *buffer = iter + 1;
                    _control_port_write(port_index, buffer_size, 0, buffer);
                }
            }
        }
    }
//  ...
```

---
Plugin: ** write_port_event(s) **
```C
#include "lv2/lv2plug.in/ns/ext/atom/forge.h"

//  LV2_Atom_Forge *forge;
//
//  `forge` should be bound to the plugin's atom output port buffer;
//  nb. remember to declare an adequate port buffer minimum size (via
//  `LV2_RESIZE_PORT__minimumSize` property) if you intend to notify in
//  bulk ie. more than one tuple or pairs (`port_index`, `port_value`)
//  in contiguous sequence.
//
//  uint32_t port_index;
//  float port_value;
//
//  `port_index` (int) is the control input port index that is desired
//  to get updated on the host-side with `port_value` (float), forming
//  one or more tuples wrapped in a LV2_ATOM__PortEvent object and sent
//  out to host.
//
    lv2_atom_forge_frame_time(forge, 0);

    LV2_Atom_Forge_Frame obj_frame;
    lv2_atom_forge_object(forge, &obj_frame, 0, _urid_map(LV2_ATOM__PortEvent));
    lv2_atom_forge_key(forge, _urid_map(LV2_ATOM__portTuple));

    LV2_Atom_Forge_Frame tup_frame;
    lv2_atom_forge_tuple(forge, &tup_frame);

    // for each (port_index, port_value) tuple ...
    lv2_atom_forge_int(forge, port_index);
    lv2_atom_forge_float(forge, port_value);
    // ...

    lv2_atom_forge_pop(forge, &tup_frame);
    lv2_atom_forge_pop(forge, &obj_frame);

//  ...
```

