### PR TITLE
eg-sampler: save and restore param:gain value

### DIFF
--- a/plugins/eg-sampler.lv2/sampler.c
+++ b/plugins/eg-sampler.lv2/sampler.c
@@ -495,6 +495,16 @@ save(LV2_Handle                instance,
 	      LV2_STATE_IS_POD | LV2_STATE_IS_PORTABLE);
 
 	free(apath);
+
+	// Store the gain value
+	const float gain = self->gain;
+	store(handle,
+	      self->uris.param_gain,
+	      &gain,
+	      sizeof(gain),
+	      self->uris.atom_Float,
+	      LV2_STATE_IS_POD | LV2_STATE_IS_PORTABLE);
+
 	return LV2_STATE_SUCCESS;
 }
 
@@ -563,6 +573,19 @@ restore(LV2_Handle                  instance,
 	}
 
 	free(path);
+
+	// Get param:gain from state
+	value = retrieve(handle, self->uris.param_gain, &size, &type, &valflags);
+	if (!value) {
+		// This is not fatal, as older versions of eg-sampler were missing this property
+		lv2_log_note(&self->logger, "Missing param:gain\n");
+		return LV2_STATE_SUCCESS;
+	} else if (type != self->uris.atom_Float) {
+		lv2_log_error(&self->logger, "Non-float param:gain\n");
+		return LV2_STATE_ERR_BAD_TYPE;
+	}
+
+	self->gain = *(const float*)value;
 
 	return LV2_STATE_SUCCESS;
 }

--- a/plugins/eg-sampler.lv2/sampler.c
+++ b/plugins/eg-sampler.lv2/sampler.c
@@ -82,6 +82,7 @@ typedef struct {
 	sf_count_t frame;
 	bool       play;
 	bool       activated;
+	bool       gain_changed;
 	bool       sample_changed;
 } Sampler;
 
@@ -436,13 +437,21 @@ run(LV2_Handle instance, uint32_t sample_count)
 	// Start a sequence in the notify output port.
 	lv2_atom_forge_sequence_head(&self->forge, &self->notify_frame, 0);
 
-	// Send update to UI if sample has changed due to state restore
-	if (self->sample_changed) {
+	// Send update to UI if gain parameter or sample have changed due to state restore
+	if (self->gain_changed || self->sample_changed) {
 		lv2_atom_forge_frame_time(&self->forge, 0);
-		write_set_file(&self->forge, &self->uris,
-		               self->sample->path,
-		               self->sample->path_len);
-		self->sample_changed = false;
+
+		if (self->gain_changed) {
+			write_set_gain(&self->forge, &self->uris, self->gain_dB);
+			self->gain_changed = false;
+		}
+
+		if (self->sample_changed) {
+			write_set_file(&self->forge, &self->uris,
+			               self->sample->path,
+			               self->sample->path_len);
+			self->sample_changed = false;
+		}
 	}
 
 	// Iterate over incoming events, emitting audio along the way
@@ -591,6 +600,7 @@ restore(LV2_Handle                  instance,
 
 	self->gain_dB = *(const float*)value;
 	self->gain = DB_CO(self->gain_dB);
+	self->gain_changed = true;
 
 	return LV2_STATE_SUCCESS;
 }

--- a/plugins/eg-sampler.lv2/sampler.ttl
+++ b/plugins/eg-sampler.lv2/sampler.ttl
@@ -58,7 +58,7 @@
 	] ;
 	state:state [
 		<http://lv2plug.in/plugins/eg-sampler#sample> <click.wav> ;
-		param:gain "1.0"^^xsd:float
+		param:gain "0.0"^^xsd:float
 	] .
 
 <http://lv2plug.in/plugins/eg-sampler#ui>

--- a/plugins/eg-sampler.lv2/uris.h
+++ b/plugins/eg-sampler.lv2/uris.h
@@ -79,6 +79,34 @@ map_sampler_uris(LV2_URID_Map* map, SamplerURIs* uris)
    ----
    []
    a patch:Set ;
+   patch:property param:gain ;
+   patch:value 0.0f .
+   ----
+*/
+static inline LV2_Atom_Forge_Ref
+write_set_gain(LV2_Atom_Forge*    forge,
+               const SamplerURIs* uris,
+               const float        gain)
+{
+	LV2_Atom_Forge_Frame frame;
+	LV2_Atom_Forge_Ref   set = lv2_atom_forge_object(
+		forge, &frame, 0, uris->patch_Set);
+
+	lv2_atom_forge_key(forge, uris->patch_property);
+	lv2_atom_forge_urid(forge, uris->param_gain);
+	lv2_atom_forge_key(forge, uris->patch_value);
+	lv2_atom_forge_float(forge, gain);
+
+	lv2_atom_forge_pop(forge, &frame);
+	return set;
+}
+
+/**
+   Write a message like the following to `forge`:
+   [source,turtle]
+   ----
+   []
+   a patch:Set ;
    patch:property eg:sample ;
    patch:value </home/me/foo.wav> .
    ----


### PR DESCRIPTION
Adds state save and restore for the gain parameter in eg-sampler.

Probably needs to handle patch:Get for it too, but one step at a time..
