### PR TITLE
eg-sampler: Fix out of bounds sample read after loading new file

### DIFF
--- a/plugins/eg-sampler.lv2/sampler.c
+++ b/plugins/eg-sampler.lv2/sampler.c
@@ -211,6 +211,10 @@ work_response(LV2_Handle instance, uint32_t size, const void* data)
   // Install the new sample
   self->sample = *(Sample* const*)data;
 
+  // Stop playing previous sample, which can be larger than new one
+  self->frame = 0;
+  self->play  = false;
+
   // Schedule work to free the old sample
   SampleMessage msg = {{sizeof(Sample*), self->uris.eg_freeSample}, old_sample};
   self->schedule->schedule_work(self->schedule->handle, sizeof(msg), &msg);


### PR DESCRIPTION
eg-sampler was crashing for me when left playing and quickly changing between a few files.
valgrind reported this:
```
==6331== Thread 25:
==6331== Invalid read of size 4
==6331==    at 0x11DA30C4: render (sampler.c:427)
==6331==    by 0x11DA3387: run (sampler.c:493)
==6331==    by 0x545602F: lilv_instance_run (lilv.h:1694)
==6331==    by 0x545A3B7: ProcessPlugin (effects.c:1725)
==6331==    by 0x489E003: Jack::JackClient::ExecuteThread() (in /usr/lib/libjackserver.so.0.1.0)
==6331==    by 0x489D7DB: Jack::JackClient::Execute() (in /usr/lib/libjackserver.so.0.1.0)
==6331==    by 0x48B922F: Jack::JackPosixThread::ThreadHandler(void*) (in /usr/lib/libjackserver.so.0.1.0)
==6331==    by 0x4927E03: start_thread (in /usr/lib/libpthread-2.21.so)
==6331==  Address 0x139de694 is 145,876 bytes inside an unallocated block of size 578,336 in arena "client"
==6331== 
==6331== Invalid read of size 4
==6331==    at 0x11DA30C4: render (sampler.c:427)
==6331==    by 0x11DA32DF: run (sampler.c:476)
==6331==    by 0x545602F: lilv_instance_run (lilv.h:1694)
==6331==    by 0x545A3B7: ProcessPlugin (effects.c:1725)
==6331==    by 0x489E003: Jack::JackClient::ExecuteThread() (in /usr/lib/libjackserver.so.0.1.0)
==6331==    by 0x489D7DB: Jack::JackClient::Execute() (in /usr/lib/libjackserver.so.0.1.0)
==6331==    by 0x48B922F: Jack::JackPosixThread::ThreadHandler(void*) (in /usr/lib/libjackserver.so.0.1.0)
==6331==    by 0x4927E03: start_thread (in /usr/lib/libpthread-2.21.so)
==6331==  Address 0x139ee694 is 208,868 bytes inside an unallocated block of size 575,792 in arena "client"
```

Under some circunstances, `self->frame` was set to a higher value than possible for the current/new sample file.
This happens because sample-change events can happen in any time frame inside the run function.
So this condition that stops playing the file:
```
      if (++self->frame == self->sample->info.frames) {
        self->play = false; // Reached end of sample
        break;
      }
```
was never reached (during the current "run").

Easily fixed by forcing the sample playback to stop when loading a new file.
