### PR TITLE
Write the output up to the event and then update the state.

### DIFF
--- a/plugins/eg-midigate.lv2/midigate.c
+++ b/plugins/eg-midigate.lv2/midigate.c
@@ -160,7 +160,11 @@ run(LV2_Handle instance, uint32_t sample_count)
   uint32_t  offset = 0;
 
   LV2_ATOM_SEQUENCE_FOREACH (self->control, ev) {
-    if (ev->body.type == self->uris.midi_MidiEvent) {
+
+	write_output(self, offset, ev->time.frames - offset);
+	offset = (uint32_t)ev->time.frames;
+
+	if (ev->body.type == self->uris.midi_MidiEvent) {
       const uint8_t* const msg = (const uint8_t*)(ev + 1);
       switch (lv2_midi_message_type(msg)) {
       case LV2_MIDI_MSG_NOTE_ON:
@@ -185,9 +189,6 @@ run(LV2_Handle instance, uint32_t sample_count)
         break;
       }
     }
-
-    write_output(self, offset, ev->time.frames - offset);
-    offset = (uint32_t)ev->time.frames;
   }
 
   write_output(self, offset, sample_count - offset);


### PR DESCRIPTION
Originally the event loop would update the state of the plugin and then write the output up to the event. This would have the effect of applying the event state to the beginning of the buffer instead of to the beginning of the event.

The correct approach is to write with the current state up to the event and then process the event and update the state.