### PR TITLE
Add possibility to change legacy LV2 port value by the plugin's DSP part

### DIFF
--- a/include/lv2/patch/patch.h
+++ b/include/lv2/patch/patch.h
@@ -1,4 +1,5 @@
 // Copyright 2012-2016 David Robillard <d@drobilla.net>
+// Copyright 2024 Vladimir Sadovnikov <sadko4u@gmail.com>
 // SPDX-License-Identifier: ISC
 
 #ifndef LV2_PATCH_PATCH_H
@@ -41,6 +42,7 @@
 #define LV2_PATCH__body           LV2_PATCH_PREFIX "body"            ///< http://lv2plug.in/ns/ext/patch#body
 #define LV2_PATCH__context        LV2_PATCH_PREFIX "context"         ///< http://lv2plug.in/ns/ext/patch#context
 #define LV2_PATCH__destination    LV2_PATCH_PREFIX "destination"     ///< http://lv2plug.in/ns/ext/patch#destination
+#define LV2_PATCH__portIndex      LV2_PATCH_PREFIX "portIndex"       ///< http://lv2plug.in/ns/ext/patch#portIndex
 #define LV2_PATCH__property       LV2_PATCH_PREFIX "property"        ///< http://lv2plug.in/ns/ext/patch#property
 #define LV2_PATCH__readable       LV2_PATCH_PREFIX "readable"        ///< http://lv2plug.in/ns/ext/patch#readable
 #define LV2_PATCH__remove         LV2_PATCH_PREFIX "remove"          ///< http://lv2plug.in/ns/ext/patch#remove

--- a/lv2/core.lv2/people.ttl
+++ b/lv2/core.lv2/people.ttl
@@ -48,3 +48,11 @@ meta:bmwiedemann
 	a foaf:Person ;
 	foaf:name "Bernhard M. Wiedemann" ;
 	foaf:mbox <bwiedemann@suse.de> .
+
+<http://lsp-plug.in/developers/v_sadovnikov>
+	a foaf:Person ;
+	foaf:name "Vladimir Sadovnikov" ;
+	foaf:nick "SadKo" ;
+	foaf:mbox <mailto:sadko4u@gmail.com> ;
+	foaf:homepage <http://lsp-plug.in/#v_sadovnikov> ;
+	rdfs:seeAlso <http://lsp-plug.in/#v_sadovnikov> .

--- a/lv2/patch.lv2/patch.meta.ttl
+++ b/lv2/patch.lv2/patch.meta.ttl
@@ -60,6 +60,20 @@ The plugin would then respond with the same patch:Set message as above.
 In this case, the plugin instance is implicitly the patch:subject,
 but a specific subject can also be given for deeper control.
 
+The plugin also may be an initiator of changing legacy lv2:port values. For that purpose it can emit another type of a patch:Set message:
+
+    :::turtle
+    [
+        a patch:Set ;
+        patch:portIndex 42 ;
+        patch:value 440.0 ;
+    ]
+
+In this case the host is responsible for handling this message and delivering the new value to the plugin and it's user interface via the ui:portNotification protocol.
+For this case, the patch:value property should be of xsd:float type.
+The plugin's custom user interface may handle such patch:Set message but take into account that host can reject the value passed in patch:Set message in case when more
+prioritized port change action like automation or user input occurred.
+
 """^^lv2:Markdown .
 
 patch:Copy

--- a/lv2/patch.lv2/patch.ttl
+++ b/lv2/patch.lv2/patch.ttl
@@ -4,6 +4,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix lv2: <http://lv2plug.in/ns/lv2core#> .
 
 <http://lv2plug.in/ns/ext/patch>
 	a owl:Ontology ;
@@ -185,6 +186,15 @@ patch:property
 	rdfs:domain patch:Message ;
 	rdfs:range rdf:Property ;
 	rdfs:comment "The property for a patch:Set or patch:Get message." .
+
+patch:portIndex
+	a rdf:Property ,
+		owl:ObjectProperty ,
+		owl:FunctionalProperty ;
+	rdfs:label "port index" ;
+	rdfs:domain patch:Set ;
+	rdfs:range xsd:unsignedInt ;
+	rdfs:comment "The index of a legacy lv2:port for modification by the patch:Set message." .
 
 patch:readable
 	a rdf:Property ,


### PR DESCRIPTION
The value of this feature: the plugin may introduce non-standard control modes like MIDI control, remote OSC control or something similar. In this case, it is not possible to synchronize changed legacy port parameters against Host, DSP and UI without having proper interface to pass the new value of the legacy parameter.

Modern plugin formats like CLAP and VST3 allow to automate the changes of the plugin's parameters from the audio thread by issuing corresponding messages or filling corresponding data structures. Even modern hosts accept the VST2's `audioMasterAutomate` callback issued by the DSP part of the plugin code - [example in JUCE framework](https://github.com/juce-framework/JUCE/blob/4ada2e1f4db082f5dd803f249f37b3bf9c5f55ef/modules/juce_audio_plugin_client/juce_audio_plugin_client_VST2.cpp#L698-L707). According to my current knowledge, there is no such feature in LV2 yet.

This PR aims to introduce such feature with minimal changes by allowing to pass legacy LV2 port index in `patch:Set` messages issued by the plugin.
In this case the host is responsible for handling this message and changing the value of the legacy LV2 port on the next `run` call. The host is also permitted to reject the requested value in case it is playing automation or handling user input.
To synchronize the changed value with plugin's UI, the host should transfer the new value via the `ui:PortNotification` message.
